### PR TITLE
Add option --no-clean to nti-cmp-scripts build

### DIFF
--- a/packages/nti-cmp-scripts/tasks/build.js
+++ b/packages/nti-cmp-scripts/tasks/build.js
@@ -1,6 +1,7 @@
 /*eslint import/no-extraneous-dependencies: 0*/
 'use strict';
 const DEBUG = process.argv.includes('--debug');
+const CLEAN = !process.argv.includes('--no-clean');
 
 const path = require('path');
 
@@ -37,7 +38,9 @@ call('node', [require.resolve('./check')]);
 call('node', [require.resolve('./test'), '--no-cache']);
 
 //clean dist
-fs.emptyDirSync(path.resolve(paths.path, 'lib'));
+if (CLEAN) {
+	fs.emptyDirSync(path.resolve(paths.path, 'lib'));
+}
 
 //call build hook
 Promise.resolve(callHook())


### PR DESCRIPTION
Adds option `nti-cmp-scripts build --no-clean`, which runs the normal build process without destroying the dist directory. This prevents the web app from needing to be restarted every time a locally linked dependency needs to be rebuilt.

This saves me 60-120 seconds every build during development
of a dependency.