### PR TITLE
emit basic info (host, port) on dev server startup

### DIFF
--- a/packages/cmp-scripts/config/webpack.config.js
+++ b/packages/cmp-scripts/config/webpack.config.js
@@ -169,11 +169,11 @@ exports = module.exports = {
 			warnings: false,
 			errors: true
 		},
-		noInfo: true,
 		proxy: [{
 			context: ['/content', '/dataserver2'],
 			target: 'http://localhost:8082',
-		}]
+		}],
+		stats: 'errors-only',
 	},
 
 	plugins: [

--- a/packages/cmp-scripts/tasks/start.js
+++ b/packages/cmp-scripts/tasks/start.js
@@ -36,9 +36,7 @@ call(require.resolve('webpack-dev-server/bin/webpack-dev-server.js'), [
 	'--config', paths.webpackDevConfig,
 	'--host', host,
 	'--port', port,
-	'--quiet',
 	'--watch',
-	// '--progress',
 	'--inline',
 	...SSL
 ]);


### PR DESCRIPTION
The webpack dev server isn't currently emitting any information on startup. These config changes allow basic info (host, port, etc.) to be printed to the console.